### PR TITLE
Add `right-margin` to `disable-mouse--bindings-targets`

### DIFF
--- a/disable-mouse.el
+++ b/disable-mouse.el
@@ -52,7 +52,7 @@
 (defconst disable-mouse--bindings-modifier-combos
   '("C-" "M-" "S-" "C-M-" "C-S-" "M-S-" "M-C-S-"))
 
-(defconst disable-mouse--bindings-targets '("mode-line" "bottom-divider" "vertical-line"))
+(defconst disable-mouse--bindings-targets '("right-margin" "mode-line" "bottom-divider" "vertical-line"))
 
 (defconst disable-mouse--multipliers '("double" "triple"))
 


### PR DESCRIPTION
This pull request adds `right-margin` to `disable-mouse--bindings-targets` to include the right margin of Emacs windows. This ensures that all mouse events in the right margin are consistently ignored.